### PR TITLE
chore: upgrade to v3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -69,20 +63,19 @@
       "dev": true
     },
     "jasmine": {
-      "version": "2.99.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.99.0.tgz",
-      "integrity": "sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+      "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
         "glob": "^7.0.6",
-        "jasmine-core": "~2.99.0"
+        "jasmine-core": "~3.1.0"
       }
     },
     "jasmine-core": {
-      "version": "2.99.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.0.tgz",
-      "integrity": "sha1-wQWrUiLaRfGwoQWAOD9a27/1bSw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+      "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "ISC",
   "devDependencies": {
-    "jasmine": "2.99.0",
-    "jasmine-core": "2.99.0"
+    "jasmine": "3.1.0",
+    "jasmine-core": "3.1.0"
   }
 }


### PR DESCRIPTION
Bumps to Jasmine v3.1, but fails with:

```
(node:41179) UnhandledPromiseRejectionWarning: TypeError: expect(...).toBeUseless is not a function
    at Promise.resolve.then (/Users/cedric/Code/tests/jasmine-v3-custom-matchers/spec/custom-matcher-in-promise.spec.js:19:32)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```